### PR TITLE
restore variable documentation

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-editor-nginx",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Nginx language for Monaco Editor.",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -14,14 +14,14 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/runtime": ">=7.10.0",
-    "@nginx/reference-lib": ">=1.0.14",
+    "@nginx/reference-lib": ">=1.1.0",
     "monaco-editor": ">=0.22.3",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@nginx/reference-lib": "^1.0.14"
+    "@nginx/reference-lib": "^1.1.0"
   },
   "devDependencies": {
     "monaco-editor": "^0.44.0"

--- a/core/src/directives.ts
+++ b/core/src/directives.ts
@@ -1,5 +1,4 @@
-import { getDirectives, Format } from '@nginx/reference-lib';
-import { Directive } from '@nginx/reference-lib/dist/index.d';
+import { getDirectives, Format, getVariables, Directive } from '@nginx/reference-lib';
 
 export type Autocomplete = {
   /** name of the NGINX module */
@@ -12,10 +11,10 @@ export type Autocomplete = {
    * nginx config */
   v?: string;
   /** markdown CSV for valid contexts */
-  c: string;
+  c?: string;
   /** markdown-formatted syntax specifications, including directive name.
    * Multiple syntaxes are seperated by newlines */
-  s: string;
+  s?: string;
 };
 
 function toAutocomplete(d: Directive): Autocomplete {
@@ -34,4 +33,10 @@ function toAutocomplete(d: Directive): Autocomplete {
   return ret;
 }
 
-export const directives = getDirectives(Format.Markdown).map(toAutocomplete);
+const variables = getVariables(Format.Markdown).map((v) => ({
+  m: v.module,
+  n: v.name,
+  d: v.description,
+}));
+
+export const directives = getDirectives(Format.Markdown).map(toAutocomplete).concat(variables);

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": ["website", "core"]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "start": "kkt start",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@wcj/dark-mode": "^1.0.13",
-    "monaco-editor-nginx": "2.0.1",
+    "monaco-editor-nginx": "2.0.2",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },


### PR DESCRIPTION
Hi, I'm working for F5 with @danielledeleo, and had an update for `@nginx/reference-lib`.

The previous version of `@nginx/reference-lib` did not have NGINX variables (like `$binary_remote_addr`), update and include those in the autocomplete array.

The old web scraper included these variables, but often had inaccurate descriptions.

See also: https://github.com/nginx/nginx-directive-reference/pull/203

I *think* I bumped the version correctly, but if you'd like anything differently please let me know and I'll adjust.